### PR TITLE
Upgrades meros to v1.1.2 (with updated types)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/react-dom": "17.0.0",
     "@types/ws": "7.4.0",
     "graphiql": "1.3.2",
-    "meros": "1.0.0",
+    "meros": "1.1.2",
     "patch-package": "6.2.2",
     "prettier": "2.2.1",
     "react": "17.0.1",

--- a/src/dev/GraphiQL.tsx
+++ b/src/dev/GraphiQL.tsx
@@ -74,18 +74,18 @@ const httpMultipartFetcher = async (
       "content-type": "application/json",
     },
     signal: abortController.signal,
-  }).then(meros);
+  }).then(r => meros<FetcherResult>(r));
 
   if (isAsyncIterable(patches)) {
-    return multiResponseParser(patches) as AsyncIterableIterator<FetcherResult>;
+    return multiResponseParser(patches);
   }
 
   return patches.json();
 };
 
-async function* multiResponseParser(
+async function* multiResponseParser<T>(
   iterator: AsyncIterableIterator<{
-    body: object | string;
+    body: T;
     json: boolean;
   }>
 ) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7445,10 +7445,10 @@ merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-meros@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/meros/-/meros-1.0.0.tgz#cb1fc818a60afc56bd86c577a9758b4510b3f027"
-  integrity sha512-gGhudbEI/7Z/5Mc3Mh2VsxWTm0byUB7O34azwchvvDRZ3oaxt5RaN80tF9mwN+plfi2JKDeIQQfJJWwuWmgqBQ==
+meros@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/meros/-/meros-1.1.2.tgz#12d5f520458ba8ae1536092824c1744fa09cf79d"
+  integrity sha512-BvOjEcEtGBOSts+lCCuqDe4LhSvzwQsQNxDB86ZY8RiAVQsPcmzxqm1/OjBBWv7vCufEEq8jstf4QJBBAHlDXg==
 
 methods@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This resolves issues in #77 (and was branched from)

Closes https://github.com/n1ru4l/graphql-bleeding-edge-playground/pull/77