### PR TITLE
Configurable Server Enpoints

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+VITE_WS_URL=ws://localhost:4000/graphql
+VITE_GRAPHQL_SERVER_URL=http://localhost:4000/graphql

--- a/README.md
+++ b/README.md
@@ -48,3 +48,9 @@ Start the frontend `yarn start`
 Visit `localhost:3000/__dev__/graphiql`
 
 Execute some operations :)
+
+## Custom server url
+
+You can point to your own/custom graphql sever by editing the variables in your `.env.development` file.
+- The `VITE_WS_URL` env variable points to your websocket connection url
+- The `VITE_GRAPHQL_SERVER_URL` env variable points to your graphql server url

--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ Execute some operations :)
 
 ## Custom server url
 
-You can point to your own/custom graphql sever by editing the variables in your `.env.development` file.
+You can point to your own/custom graphql sever by editing the variables in your `.env` file.
 - The `VITE_WS_URL` env variable points to your websocket connection url
 - The `VITE_GRAPHQL_SERVER_URL` env variable points to your graphql server url

--- a/src/dev/GraphiQL.tsx
+++ b/src/dev/GraphiQL.tsx
@@ -27,7 +27,7 @@ const ioFetcher = (graphQLParams: FetcherParams) =>
   ioGraphQLClient.execute({ ...graphQLParams, operation: graphQLParams.query });
 
 const wsClient = createClient({
-  url: "ws://localhost:4000/graphql",
+  url: import.meta.env.VITE_WS_URL,
   lazy: false,
 });
 
@@ -54,7 +54,7 @@ const httpMultipartFetcher = async (
 
     return makeAsyncIterableIteratorFromSink<FetcherResult>((sink) => {
       const subscription = new SSESubscription({
-        url: "http://localhost:4000/graphql",
+        url: import.meta.env.VITE_GRAPHQL_SERVER_URL,
         searchParams,
         onNext: (value) => {
           sink.next(JSON.parse(value));
@@ -67,7 +67,7 @@ const httpMultipartFetcher = async (
     });
   }
 
-  const patches = await fetch("http://localhost:4000/graphql", {
+  const patches = await fetch(import.meta.env.VITE_GRAPHQL_SERVER_URL, {
     method: "POST",
     body: JSON.stringify(graphQLParams),
     headers: {
@@ -159,7 +159,7 @@ const defaultQuery = /* GraphQL */ `
     randomHash
   }
 
-  # 
+  #
   # Query using @defer
   #
   # defer can be used on fragments in order to defer sending a part of the result to the client,
@@ -218,7 +218,7 @@ const defaultQuery = /* GraphQL */ `
   #
   # OneOf input types allow polymorphic input fields. They are currently in the RFC stage. https://github.com/graphql/graphql-spec/pull/825
   # The @envelop/extended-validation plugin allows using the feature today! https://github.com/dotansimha/envelop/tree/main/packages/plugins/extended-validation
-  # 
+  #
   # The input type LogEvent type is marked as a oneOf type. Therefore, the validation of the operation only passes if the input has either a stringEvent or booleanEvent key.
   # Providing both or neither would result in a validation error.
   #

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_WS_URL: string;
+  readonly VITE_GRAPHQL_SERVER_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
This small PR makes it possible to point to a custom server. This is useful when someone is building their graphql sever.

**Changes made**
- added a `.env` file with some variables. They default to URLs of the provided server code within this repo
- Updated the `readme.md` on how to point to a custom server.
- Referenced the `env` variables within the code.

